### PR TITLE
Fix default adb path + remove date from logcat

### DIFF
--- a/AndroidTools/AndroidTools.xcodeproj/project.pbxproj
+++ b/AndroidTools/AndroidTools.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		819A32E12BF676E300AD10E3 /* GetAdbVersionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32E02BF676E300AD10E3 /* GetAdbVersionError.swift */; };
 		819A32E32BF6774D00AD10E3 /* AdbRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32E22BF6774D00AD10E3 /* AdbRepositoryImpl.swift */; };
 		819A32E72BF67C9200AD10E3 /* DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32E62BF67C9200AD10E3 /* DisplayableError.swift */; };
+		819A32E92BF69B2F00AD10E3 /* ShellHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32E82BF69B2F00AD10E3 /* ShellHelper.swift */; };
+		819A32EB2BF6A23100AD10E3 /* GetAdbPathUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32EA2BF6A23100AD10E3 /* GetAdbPathUseCase.swift */; };
+		819A32ED2BF6A5DC00AD10E3 /* SetAdbPathUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32EC2BF6A5DC00AD10E3 /* SetAdbPathUseCase.swift */; };
 		81A067C72BEEBA0100E83DEF /* GetAdbVersionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A067C62BEEBA0100E83DEF /* GetAdbVersionUseCase.swift */; };
 		81B7900D2BEBA7E5008E7359 /* LogcatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B7900C2BEBA7E5008E7359 /* LogcatViewModel.swift */; };
 		81B7900F2BEBA7F3008E7359 /* LogcatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B7900E2BEBA7F3008E7359 /* LogcatView.swift */; };
@@ -121,6 +124,9 @@
 		819A32E02BF676E300AD10E3 /* GetAdbVersionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAdbVersionError.swift; sourceTree = "<group>"; };
 		819A32E22BF6774D00AD10E3 /* AdbRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdbRepositoryImpl.swift; sourceTree = "<group>"; };
 		819A32E62BF67C9200AD10E3 /* DisplayableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableError.swift; sourceTree = "<group>"; };
+		819A32E82BF69B2F00AD10E3 /* ShellHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHelper.swift; sourceTree = "<group>"; };
+		819A32EA2BF6A23100AD10E3 /* GetAdbPathUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAdbPathUseCase.swift; sourceTree = "<group>"; };
+		819A32EC2BF6A5DC00AD10E3 /* SetAdbPathUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAdbPathUseCase.swift; sourceTree = "<group>"; };
 		81A067C62BEEBA0100E83DEF /* GetAdbVersionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAdbVersionUseCase.swift; sourceTree = "<group>"; };
 		81B7900C2BEBA7E5008E7359 /* LogcatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogcatViewModel.swift; sourceTree = "<group>"; };
 		81B7900E2BEBA7F3008E7359 /* LogcatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogcatView.swift; sourceTree = "<group>"; };
@@ -165,6 +171,7 @@
 		814319532BC6B3AC00044934 /* Commons */ = {
 			isa = PBXGroup;
 			children = (
+				819A32E82BF69B2F00AD10E3 /* ShellHelper.swift */,
 				81E6A7642BC5D7020034EBFB /* AdbHelper.swift */,
 				814319542BC6B3B100044934 /* Extensions */,
 				8109D3632BF128A8001A4B5E /* Constants.swift */,
@@ -410,6 +417,8 @@
 				81F41C5E2BEA95FB005F1730 /* DeleteFileItemUseCase.swift */,
 				81F41C602BEA995D005F1730 /* ImportFileUseCase.swift */,
 				81A067C62BEEBA0100E83DEF /* GetAdbVersionUseCase.swift */,
+				819A32EA2BF6A23100AD10E3 /* GetAdbPathUseCase.swift */,
+				819A32EC2BF6A5DC00AD10E3 /* SetAdbPathUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -493,6 +502,7 @@
 				81B790172BEC17B0008E7359 /* LogEntryItem.swift in Sources */,
 				819A32DF2BF6767A00AD10E3 /* AdbRepository.swift in Sources */,
 				81E6A7592BC5CD9D0034EBFB /* DeviceInformationView.swift in Sources */,
+				819A32ED2BF6A5DC00AD10E3 /* SetAdbPathUseCase.swift in Sources */,
 				81B7900D2BEBA7E5008E7359 /* LogcatViewModel.swift in Sources */,
 				814319522BC6715B00044934 /* InstallApplicationViewModel.swift in Sources */,
 				8109D3662BF141B0001A4B5E /* ApplicationSettingsViewModel.swift in Sources */,
@@ -515,6 +525,7 @@
 				81F41C5B2BEA4DF4005F1730 /* TableView.swift in Sources */,
 				816A1D402BE8CDE000E7DA71 /* InstallApplicationError.swift in Sources */,
 				8109D3602BF12575001A4B5E /* ApplicationSettingsView.swift in Sources */,
+				819A32EB2BF6A23100AD10E3 /* GetAdbPathUseCase.swift in Sources */,
 				81E982392BDD3B480004B154 /* CheckForUpdateView.swift in Sources */,
 				810E8E202BE9311100ED561A /* FileRepositoryImpl.swift in Sources */,
 				81B790112BEBA9E8008E7359 /* LogEntryModel.swift in Sources */,
@@ -542,6 +553,7 @@
 				81E982312BDD0F190004B154 /* RebootDeviceUseCase.swift in Sources */,
 				817EE8592BC81D4100740D4A /* FileExplorerViewModel.swift in Sources */,
 				81E982372BDD3A740004B154 /* CheckForUpdateViewModel.swift in Sources */,
+				819A32E92BF69B2F00AD10E3 /* ShellHelper.swift in Sources */,
 				816A1D3C2BE8CAC300E7DA71 /* ApplicationRepositoryImpl.swift in Sources */,
 				81F41C632BEAA7B0005F1730 /* GridView.swift in Sources */,
 				819A32E32BF6774D00AD10E3 /* AdbRepositoryImpl.swift in Sources */,

--- a/AndroidTools/AndroidTools.xcodeproj/project.pbxproj
+++ b/AndroidTools/AndroidTools.xcodeproj/project.pbxproj
@@ -701,7 +701,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"AndroidTools/Preview Content\"";
 				DEVELOPMENT_TEAM = H9DTPYA8RY;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -715,7 +715,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.thomasbernard03.AndroidTools;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -733,7 +733,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"AndroidTools/Preview Content\"";
 				DEVELOPMENT_TEAM = H9DTPYA8RY;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -747,7 +747,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.thomasbernard03.AndroidTools;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/AndroidTools/AndroidTools.xcodeproj/project.pbxproj
+++ b/AndroidTools/AndroidTools.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		817854852BC59F6500B5B2EE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 817854842BC59F6500B5B2EE /* Preview Assets.xcassets */; };
 		817EE8592BC81D4100740D4A /* FileExplorerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817EE8582BC81D4100740D4A /* FileExplorerViewModel.swift */; };
 		817EE85D2BC8247F00740D4A /* FileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817EE85C2BC8247F00740D4A /* FileItem.swift */; };
+		819A32DF2BF6767A00AD10E3 /* AdbRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32DE2BF6767A00AD10E3 /* AdbRepository.swift */; };
+		819A32E12BF676E300AD10E3 /* GetAdbVersionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32E02BF676E300AD10E3 /* GetAdbVersionError.swift */; };
+		819A32E32BF6774D00AD10E3 /* AdbRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32E22BF6774D00AD10E3 /* AdbRepositoryImpl.swift */; };
+		819A32E72BF67C9200AD10E3 /* DisplayableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819A32E62BF67C9200AD10E3 /* DisplayableError.swift */; };
 		81A067C72BEEBA0100E83DEF /* GetAdbVersionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A067C62BEEBA0100E83DEF /* GetAdbVersionUseCase.swift */; };
 		81B7900D2BEBA7E5008E7359 /* LogcatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B7900C2BEBA7E5008E7359 /* LogcatViewModel.swift */; };
 		81B7900F2BEBA7F3008E7359 /* LogcatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B7900E2BEBA7F3008E7359 /* LogcatView.swift */; };
@@ -113,6 +117,10 @@
 		817854862BC59F6500B5B2EE /* AndroidTools.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AndroidTools.entitlements; sourceTree = "<group>"; };
 		817EE8582BC81D4100740D4A /* FileExplorerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerViewModel.swift; sourceTree = "<group>"; };
 		817EE85C2BC8247F00740D4A /* FileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileItem.swift; sourceTree = "<group>"; };
+		819A32DE2BF6767A00AD10E3 /* AdbRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdbRepository.swift; sourceTree = "<group>"; };
+		819A32E02BF676E300AD10E3 /* GetAdbVersionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAdbVersionError.swift; sourceTree = "<group>"; };
+		819A32E22BF6774D00AD10E3 /* AdbRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdbRepositoryImpl.swift; sourceTree = "<group>"; };
+		819A32E62BF67C9200AD10E3 /* DisplayableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableError.swift; sourceTree = "<group>"; };
 		81A067C62BEEBA0100E83DEF /* GetAdbVersionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAdbVersionUseCase.swift; sourceTree = "<group>"; };
 		81B7900C2BEBA7E5008E7359 /* LogcatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogcatViewModel.swift; sourceTree = "<group>"; };
 		81B7900E2BEBA7F3008E7359 /* LogcatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogcatView.swift; sourceTree = "<group>"; };
@@ -283,6 +291,7 @@
 				816A1D392BE8CAA300E7DA71 /* ApplicationRepository.swift */,
 				816A1D482BE8F67000E7DA71 /* DeviceRepository.swift */,
 				810E8E212BE9312B00ED561A /* FileRepository.swift */,
+				819A32DE2BF6767A00AD10E3 /* AdbRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -291,6 +300,8 @@
 			isa = PBXGroup;
 			children = (
 				816A1D3F2BE8CDE000E7DA71 /* InstallApplicationError.swift */,
+				819A32E02BF676E300AD10E3 /* GetAdbVersionError.swift */,
+				819A32E62BF67C9200AD10E3 /* DisplayableError.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -301,6 +312,7 @@
 				816A1D3B2BE8CAC300E7DA71 /* ApplicationRepositoryImpl.swift */,
 				816A1D462BE8F66100E7DA71 /* DeviceRepositoryImpl.swift */,
 				810E8E1F2BE9311100ED561A /* FileRepositoryImpl.swift */,
+				819A32E22BF6774D00AD10E3 /* AdbRepositoryImpl.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -479,10 +491,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				81B790172BEC17B0008E7359 /* LogEntryItem.swift in Sources */,
+				819A32DF2BF6767A00AD10E3 /* AdbRepository.swift in Sources */,
 				81E6A7592BC5CD9D0034EBFB /* DeviceInformationView.swift in Sources */,
 				81B7900D2BEBA7E5008E7359 /* LogcatViewModel.swift in Sources */,
 				814319522BC6715B00044934 /* InstallApplicationViewModel.swift in Sources */,
 				8109D3662BF141B0001A4B5E /* ApplicationSettingsViewModel.swift in Sources */,
+				819A32E12BF676E300AD10E3 /* GetAdbVersionError.swift in Sources */,
 				814319562BC6B3C000044934 /* UTTypeExtensions.swift in Sources */,
 				81E6A7512BC5CC260034EBFB /* MenuView.swift in Sources */,
 				816A1D452BE8D3A200E7DA71 /* CircleWavesAnimation.swift in Sources */,
@@ -509,6 +523,7 @@
 				81B7900F2BEBA7F3008E7359 /* LogcatView.swift in Sources */,
 				814319502BC6715100044934 /* InstallApplicationView.swift in Sources */,
 				81F41C5F2BEA95FB005F1730 /* DeleteFileItemUseCase.swift in Sources */,
+				819A32E72BF67C9200AD10E3 /* DisplayableError.swift in Sources */,
 				816A1D472BE8F66100E7DA71 /* DeviceRepositoryImpl.swift in Sources */,
 				810E8E222BE9312B00ED561A /* FileRepository.swift in Sources */,
 				812A62C12BC70C3E00388105 /* IntExtensions.swift in Sources */,
@@ -529,6 +544,7 @@
 				81E982372BDD3A740004B154 /* CheckForUpdateViewModel.swift in Sources */,
 				816A1D3C2BE8CAC300E7DA71 /* ApplicationRepositoryImpl.swift in Sources */,
 				81F41C632BEAA7B0005F1730 /* GridView.swift in Sources */,
+				819A32E32BF6774D00AD10E3 /* AdbRepositoryImpl.swift in Sources */,
 				812A62BF2BC708D400388105 /* DeviceInformationModel.swift in Sources */,
 				810E8E1E2BE92EE600ED561A /* FileExplorerResultModel.swift in Sources */,
 				812AB6EB2BD3AFFE00DB60A5 /* HomeView.swift in Sources */,

--- a/AndroidTools/AndroidTools/Commons/AdbHelper.swift
+++ b/AndroidTools/AndroidTools/Commons/AdbHelper.swift
@@ -11,9 +11,6 @@ class AdbHelper {
     
     private let adbRepository : AdbRepository = AdbRepositoryImpl()
     
-    var adbPath: String {
-         UserDefaults.standard.string(forKey: "adbPath") ?? ""
-     }
     
     func getDevices() -> [DeviceListModel] {
         let command = "devices -l | awk 'NR>1 {print $1}'"
@@ -56,24 +53,6 @@ class AdbHelper {
     }
     
     func runAdbCommand(_ command: String, outputHandler: @escaping (String) -> Void) {
-        print("Running command:\n adb \(command)")
-        let task = Process()
-        let pipe = Pipe()
-
-        task.standardOutput = pipe
-        task.standardError = pipe
-        task.arguments = ["-c", "\(adbPath) \(command)"]
-        task.launchPath = "/bin/sh"
-
-        pipe.fileHandleForReading.readabilityHandler = { fileHandle in
-            let data = fileHandle.availableData
-            if let output = String(data: data, encoding: .utf8) {
-                outputHandler(output)
-            }
-        }
-
-        task.launch()
-        task.waitUntilExit()
-        pipe.fileHandleForReading.readabilityHandler = nil
+        adbRepository.runAdbCommand(command, outputHandler: outputHandler)
     }
 }

--- a/AndroidTools/AndroidTools/Commons/AdbHelper.swift
+++ b/AndroidTools/AndroidTools/Commons/AdbHelper.swift
@@ -9,8 +9,10 @@ import Foundation
 
 class AdbHelper {
     
+    private let adbRepository : AdbRepository = AdbRepositoryImpl()
+    
     var adbPath: String {
-         UserDefaults.standard.string(forKey: "adbPath") ?? "/usr/local/bin/adb"
+         UserDefaults.standard.string(forKey: "adbPath") ?? ""
      }
     
     func getDevices() -> [DeviceListModel] {
@@ -49,20 +51,8 @@ class AdbHelper {
     }
     
     func runAdbCommand(_ command: String) -> String {
-        print("Running command:\nadb \(command)")
-        let task = Process()
-        let pipe = Pipe()
-
-        task.standardOutput = pipe
-        task.standardError = pipe
-        task.arguments = ["-c", "\(adbPath) \(command)"]
-        task.launchPath = "/bin/sh"
-        task.launch()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        print("Result:\n\(output)")
-        return output
+        let result = try? adbRepository.runAdbCommand(command)
+        return result ?? ""
     }
     
     func runAdbCommand(_ command: String, outputHandler: @escaping (String) -> Void) {

--- a/AndroidTools/AndroidTools/Commons/ShellHelper.swift
+++ b/AndroidTools/AndroidTools/Commons/ShellHelper.swift
@@ -1,0 +1,34 @@
+//
+//  ShellHelper.swift
+//  AndroidTools
+//
+//  Created by Thomas Bernard on 16/05/2024.
+//
+
+import Foundation
+import os
+
+class ShellHelper {
+    
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: AdbRepositoryImpl.self)
+    )
+    
+    func runAdbCommand(_ command: String) -> String {
+        logger.info("Running command:\n\(command)")
+        let task = Process()
+        let pipe = Pipe()
+
+        task.standardOutput = pipe
+        task.standardError = pipe
+        task.arguments = ["-c", command]
+        task.launchPath = "/bin/sh"
+        task.launch()
+        
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        logger.info("Result:\n\(output)")
+        return output
+    }
+}

--- a/AndroidTools/AndroidTools/Commons/ShellHelper.swift
+++ b/AndroidTools/AndroidTools/Commons/ShellHelper.swift
@@ -31,4 +31,26 @@ class ShellHelper {
         logger.info("Result:\n\(output)")
         return output
     }
+    
+    func runAdbCommand(_ command: String, outputHandler: @escaping (String) -> Void) {
+        logger.info("Running command:\n\(command)")
+        let task = Process()
+        let pipe = Pipe()
+
+        task.standardOutput = pipe
+        task.standardError = pipe
+        task.arguments = ["-c", command]
+        task.launchPath = "/bin/sh"
+
+        pipe.fileHandleForReading.readabilityHandler = { fileHandle in
+            let data = fileHandle.availableData
+            if let output = String(data: data, encoding: .utf8) {
+                outputHandler(output)
+            }
+        }
+
+        task.launch()
+        task.waitUntilExit()
+        pipe.fileHandleForReading.readabilityHandler = nil
+    }
 }

--- a/AndroidTools/AndroidTools/Data/Repositories/AdbRepositoryImpl.swift
+++ b/AndroidTools/AndroidTools/Data/Repositories/AdbRepositoryImpl.swift
@@ -35,6 +35,11 @@ class AdbRepositoryImpl : AdbRepository {
         return shellHelper.runAdbCommand("\(adbPath) \(command)")
     }
     
+    func runAdbCommand(_ command: String, outputHandler: @escaping (String) -> Void) {
+        return shellHelper.runAdbCommand("\(adbPath) \(command)", outputHandler: outputHandler)
+    }
+    
+    
     func getVersion() throws -> String {
         let result = try runAdbCommand("version")
         

--- a/AndroidTools/AndroidTools/Data/Repositories/AdbRepositoryImpl.swift
+++ b/AndroidTools/AndroidTools/Data/Repositories/AdbRepositoryImpl.swift
@@ -1,0 +1,55 @@
+//
+//  AdbRepository.swift
+//  AndroidTools
+//
+//  Created by Thomas Bernard on 16/05/2024.
+//
+
+import Foundation
+import os
+
+class AdbRepositoryImpl : AdbRepository {
+    private var adbPath: String {
+        UserDefaults.standard.string(forKey: "adbPath") ?? "/usr/local/bin/adb"
+    }
+    
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: AdbRepositoryImpl.self)
+    )
+    
+    func runAdbCommand(_ command: String) throws -> String {
+        logger.info("Running command:\nadb \(command)")
+        let task = Process()
+        let pipe = Pipe()
+
+        task.standardOutput = pipe
+        task.standardError = pipe
+        task.arguments = ["-c", "\(adbPath) \(command)"]
+        task.launchPath = "/bin/sh"
+        task.launch()
+        
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        logger.info("Result:\n\(output)")
+        return output
+    }
+    
+    func getVersion() throws -> String {
+        let result = try runAdbCommand("version")
+        
+        let lines = result.split(separator: "\n")
+        
+        // Find the line that starts with "Version"
+        if let versionLine = lines.first(where: { $0.starts(with: "Version") }) {
+            
+            let version = versionLine
+                .replacingOccurrences(of: "Version ", with: "")
+                .split(separator: " ")
+                .first ?? ""
+            return String(version)
+        }
+        
+        return ""
+    }
+}

--- a/AndroidTools/AndroidTools/Domain/Models/Errors/DisplayableError.swift
+++ b/AndroidTools/AndroidTools/Domain/Models/Errors/DisplayableError.swift
@@ -1,0 +1,12 @@
+//
+//  DisplayableError.swift
+//  AndroidTools
+//
+//  Created by Thomas Bernard on 16/05/2024.
+//
+
+import Foundation
+
+enum DisplayableError : Error {
+    case error(message : String)
+}

--- a/AndroidTools/AndroidTools/Domain/Models/Errors/GetAdbVersionError.swift
+++ b/AndroidTools/AndroidTools/Domain/Models/Errors/GetAdbVersionError.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum AdbError : Error {
     case notFound(path : String)
+    case notExists
 }

--- a/AndroidTools/AndroidTools/Domain/Models/Errors/GetAdbVersionError.swift
+++ b/AndroidTools/AndroidTools/Domain/Models/Errors/GetAdbVersionError.swift
@@ -1,0 +1,12 @@
+//
+//  AdbError.swift
+//  AndroidTools
+//
+//  Created by Thomas Bernard on 16/05/2024.
+//
+
+import Foundation
+
+enum AdbError : Error {
+    case notFound(path : String)
+}

--- a/AndroidTools/AndroidTools/Domain/Repositories/AdbRepository.swift
+++ b/AndroidTools/AndroidTools/Domain/Repositories/AdbRepository.swift
@@ -13,4 +13,12 @@ protocol AdbRepository {
     
     
     func getVersion() throws -> String
+    
+    /**
+     Return the executable path of adb
+     - Returns: Executable path of adb
+     */
+    func getPath() throws -> String
+    
+    func setPath(path : String?) -> String
 }

--- a/AndroidTools/AndroidTools/Domain/Repositories/AdbRepository.swift
+++ b/AndroidTools/AndroidTools/Domain/Repositories/AdbRepository.swift
@@ -1,0 +1,16 @@
+//
+//  AdbRepository.swift
+//  AndroidTools
+//
+//  Created by Thomas Bernard on 16/05/2024.
+//
+
+import Foundation
+
+protocol AdbRepository {
+    
+    func runAdbCommand(_ command: String) throws -> String
+    
+    
+    func getVersion() throws -> String
+}

--- a/AndroidTools/AndroidTools/Domain/Repositories/AdbRepository.swift
+++ b/AndroidTools/AndroidTools/Domain/Repositories/AdbRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol AdbRepository {
     
     func runAdbCommand(_ command: String) throws -> String
+    func runAdbCommand(_ command: String, outputHandler: @escaping (String) -> Void)
     
     
     func getVersion() throws -> String

--- a/AndroidTools/AndroidTools/Domain/UseCases/GetAdbPathUseCase.swift
+++ b/AndroidTools/AndroidTools/Domain/UseCases/GetAdbPathUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  GetAdbPathUseCase.swift
+//  AndroidTools
+//
+//  Created by Thomas Bernard on 16/05/2024.
+//
+
+import Foundation
+
+class GetAdbPathUseCase {
+    private let adbRepository : AdbRepository = AdbRepositoryImpl()
+    
+    func execute() -> Result<String, DisplayableError> {
+        do {
+            let path = try adbRepository.getPath()
+            return .success(path)
+        }
+        catch {
+            return .failure(.error(message: "Can't find adb, set it manually"))
+        }
+    }
+}

--- a/AndroidTools/AndroidTools/Domain/UseCases/GetAdbVersionUseCase.swift
+++ b/AndroidTools/AndroidTools/Domain/UseCases/GetAdbVersionUseCase.swift
@@ -8,23 +8,18 @@
 import Foundation
 
 class GetAdbVersionUseCase {
-    private let adbHelper : AdbHelper = AdbHelper()
+    private let adbRepository : AdbRepository = AdbRepositoryImpl()
     
-    func execute() -> String {
-        let result = adbHelper.runAdbCommand("version")
-        
-        let lines = result.split(separator: "\n")
-        
-        // Find the line that starts with "Version"
-        if let versionLine = lines.first(where: { $0.starts(with: "Version") }) {
-            
-            let version = versionLine
-                .replacingOccurrences(of: "Version ", with: "")
-                .split(separator: " ")
-                .first ?? ""
-            return String(version)
+    func execute() -> Result<String, DisplayableError> {
+        do {
+            let version = try adbRepository.getVersion()
+            return .success(version)
         }
-        
-        return ""
+        catch AdbError.notFound(let path) {
+            return .failure(.error(message: "Adb path not found at \(path), you can change the path in settings"))
+        }
+        catch {
+            return .failure(.error(message: "Unknown error"))
+        }
     }
 }

--- a/AndroidTools/AndroidTools/Domain/UseCases/SetAdbPathUseCase.swift
+++ b/AndroidTools/AndroidTools/Domain/UseCases/SetAdbPathUseCase.swift
@@ -1,0 +1,16 @@
+//
+//  SetAdbPathUseCase.swift
+//  AndroidTools
+//
+//  Created by Thomas Bernard on 16/05/2024.
+//
+
+import Foundation
+
+class SetAdbPathUseCase {
+    private let adbRepository : AdbRepository = AdbRepositoryImpl()
+    
+    func execute(path : String?) -> String {
+        return adbRepository.setPath(path: path)
+    }
+}

--- a/AndroidTools/AndroidTools/Presentation/Logcat/LogEntryItem.swift
+++ b/AndroidTools/AndroidTools/Presentation/Logcat/LogEntryItem.swift
@@ -18,20 +18,21 @@ struct LogEntryItem: View {
     
     private var dateFormatter : DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateFormat = "dd/MM/yy HH:mm:ss.SSS"
+        formatter.dateFormat = "HH:mm:ss.SSS"
         return formatter
     }
     
     var body: some View {
         HStack {
             Text("\(date, formatter: dateFormatter)")
-                .frame(width: 150, alignment: .leading)
+                .frame(width: 90, alignment: .leading)
             
             Text("\(processId)-\(threadId)")
                 .frame(width: 90)
             
             Text(tag)
-                .frame(width:150)
+                .frame(width:150, alignment: .leading)
+                
             
             Text(level.rawValue)
                 .frame(width: 26, height: 26)
@@ -42,7 +43,7 @@ struct LogEntryItem: View {
             Text(message)
                 .foregroundColor(level.color())
                 .fixedSize(horizontal: true, vertical:true)
-        }
+        }.lineLimit(1)
     }
 }
 

--- a/AndroidTools/AndroidTools/Presentation/Settings/ApplicationSettingsView.swift
+++ b/AndroidTools/AndroidTools/Presentation/Settings/ApplicationSettingsView.swift
@@ -11,19 +11,16 @@ struct ApplicationSettingsView: View {
     
     @StateObject private var viewModel = ApplicationSettingsViewModel()
     
-    @AppStorage("adbPath") private var adbPath = "/usr/local/bin/adb"
-    
-    
     private func openFinderToSelectADB() {
         let panel = NSOpenPanel()
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.directoryURL = URL(fileURLWithPath: adbPath)
+        panel.directoryURL = URL(fileURLWithPath: viewModel.adbPath)
         
         panel.begin { response in
             if response == .OK, let url = panel.url {
-                self.adbPath = url.path
+                viewModel.setAdbPath(path: url.path)
                 viewModel.getAdbVersion()
             }
         }
@@ -51,11 +48,17 @@ struct ApplicationSettingsView: View {
                 }
                 
                 HStack {
-                    TextField("", text:$adbPath)
+                    TextField("", text:$viewModel.adbPath)
                         .disabled(true)
                         .padding(.leading, -10)
                     
-                    Button("Change path"){
+                    Button("Reset adb path"){
+                        viewModel.resetAdbPath()
+                    }
+            
+   
+                    
+                    Button("Change path manualy"){
                         openFinderToSelectADB()
                     }
                 }
@@ -82,6 +85,7 @@ struct ApplicationSettingsView: View {
         }
         .onAppear {
             viewModel.getAdbVersion()
+            viewModel.getAdbPath()
         }
     }
 }

--- a/AndroidTools/AndroidTools/Presentation/Settings/ApplicationSettingsViewModel.swift
+++ b/AndroidTools/AndroidTools/Presentation/Settings/ApplicationSettingsViewModel.swift
@@ -24,6 +24,15 @@ class ApplicationSettingsViewModel : ObservableObject {
     
     func getAdbVersion(){
         adbVersion = ""
-        adbVersion = getAdbVersionUseCase.execute()
+        let result = getAdbVersionUseCase.execute()
+        
+        switch(result){
+        case .success(let version) : do {
+            self.adbVersion = version
+        }
+        case .failure(let message) : do {
+            // TODO diplay error
+        }
+        }
     }
 }

--- a/AndroidTools/AndroidTools/Presentation/Settings/ApplicationSettingsViewModel.swift
+++ b/AndroidTools/AndroidTools/Presentation/Settings/ApplicationSettingsViewModel.swift
@@ -11,8 +11,15 @@ import Sparkle
 @Observable
 class ApplicationSettingsViewModel : ObservableObject {
     let updaterController : SPUStandardUpdaterController
+    
     private let getAdbVersionUseCase : GetAdbVersionUseCase = GetAdbVersionUseCase()
+    private let getAdbPathUseCase : GetAdbPathUseCase = GetAdbPathUseCase()
+    private let setAdbPathUseCase : SetAdbPathUseCase = SetAdbPathUseCase()
+    
     var adbVersion = ""
+    var adbPath = ""
+    
+    var toast : Toast? = nil
     
     init(){
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
@@ -31,8 +38,31 @@ class ApplicationSettingsViewModel : ObservableObject {
             self.adbVersion = version
         }
         case .failure(let message) : do {
-            // TODO diplay error
+            toast = Toast(style: .error, message: "Error : \n\(message)")
         }
         }
+    }
+    
+    func getAdbPath(){
+        let result = getAdbPathUseCase.execute()
+        
+        switch(result){
+        case .success(let path) : do {
+            self.adbPath = path
+        }
+        case .failure(let message) : do {
+            toast = Toast(style: .error, message: "Error : \n\(message)")
+        }
+        }
+    }
+    
+    func setAdbPath(path : String){
+       adbPath = setAdbPathUseCase.execute(path: path)
+        getAdbVersion()
+    }
+    
+    func resetAdbPath(){
+       adbPath = setAdbPathUseCase.execute(path: nil)
+        getAdbVersion()
     }
 }

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>AndroidTools</title>
         <item>
-            <title>1.3.0</title>
-            <pubDate>Wed, 15 May 2024 16:59:53 +0200</pubDate>
-            <sparkle:version>4</sparkle:version>
-            <sparkle:shortVersionString>1.3.0</sparkle:shortVersionString>
+            <title>1.3.1</title>
+            <pubDate>Thu, 16 May 2024 23:12:54 +0200</pubDate>
+            <sparkle:version>5</sparkle:version>
+            <sparkle:shortVersionString>1.3.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/ThomasBernard03/AndroidTools/releases/download/1.3.0/AndroidTools.dmg" length="2429018" type="application/octet-stream" sparkle:edSignature="e9+k4dx4usup3YtE9jU1jMQDXW8ZBfXpAEhUr+Cv2luujQ5p3NGPLCzigNtpqXXZAkc628RzhLrb95ZAUucjBA=="/>
+            <enclosure url="https://github.com/ThomasBernard03/AndroidTools/releases/download/1.3.1/AndroidTools.dmg" length="2470231" type="application/octet-stream" sparkle:edSignature="Eqd83T28Swa1A4AXxG9NUxk01TrA5P2kOLatzn0QNSS13EQj2sL5EAx7KmCWJ9o1N303lUbhSNL7MFbhGZ16AA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
The default adb path will now be defined by the "which adb" command
The date has been removed from the logcat (useless), we keep only the hour, minutes and miliseconds.